### PR TITLE
fix: leave the ASIC in reset after startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ After programming bitaxe-raw to your Bitaxe, if you ever want to change the firm
 ## Running
 When connected, this usbserial firmware will create two serial ports. Usually the first serial port is "control serial" like I2C, GPIO, and ADC. The second serial port is "data serial" and is pass through UART.
 
+After startup, the ASIC is held in reset by GPIO RST_N in order to minimize heat and power until the host device is connected and ready to use the ASIC. Enable it by setting RST_N High via the control serial port.
+
 ### Data Serial
 - Second serial port
 - All data is passed through, both directions.

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ async fn main(spawner: Spawner) {
     };
 
     let gpio_pins = control::gpio::Pins {
-        asic_resetn: gpio::Output::new(p.GPIO1, gpio::Level::High, gpio::OutputConfig::default()),
+        asic_resetn: gpio::Output::new(p.GPIO1, gpio::Level::Low, gpio::OutputConfig::default()),
     };
 
     let mut adc_config = adc::AdcConfig::default();


### PR DESCRIPTION
Leave the ASIC in reset after startup by defaulting the RST_N GPIO to LO. This minimizes heat and power until the host device is connected and begins to use the ASIC.