### PR TITLE
docs: clarify how GPIO command values map to pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Example:
 
 Commands:
 
-- Pin Number
+- RST_N: 0x00
 
 Data:
 


### PR DESCRIPTION
Document the GPIO command values as a map of pin names to values instead of implying the value corresponds to a pin number. This better matches the current implementation, which uses a discrete list of GPIOs (at this time, containing only RST_N), and uses the command value to index into that list.

Note, there's some room for confusion about RST_N. At the processor, the signal is named RST, but at the ASIC (after a level shifter) it's named RST_N. Use RST_N in the documentation to make the signal's active-low behavior clear.