### PR TITLE
build: pin esp toolchain to 1.93.0.0 to avoid LLVM 21 miscompile

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,15 @@ RUSTUP_TOOLCHAIN=stable cargo install espup --locked
 ```
 
 ```bash
-espup install
+espup install --toolchain-version 1.93.0.0
 ```
+
+Pin the toolchain to 1.93.0.0. Newer esp toolchains (1.94.x, 1.95.x)
+ship LLVM 21, whose Xtensa backend miscompiles optimized builds and
+aborts with `rustc-LLVM ERROR: Cannot select ... XtensaISD::PCREL_WRAPPER`.
+1.93.0.0 (LLVM 20) is the last known-good version. `build.rs` refuses to
+build on the affected toolchains, so an accidental `espup update` fails
+fast with the same instructions instead of a cryptic backend crash.
 
 ### Install flashing tools
 ```bash

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,46 @@
 fn main() {
     linker_be_nice();
+    check_llvm_version();
     println!("cargo:rustc-link-arg=-Tdefmt.x");
     // make sure linkall.x is the last linker script (otherwise might cause problems with flip-link)
     println!("cargo:rustc-link-arg=-Tlinkall.x");
+}
+
+// esp toolchains built on LLVM 21 (Xtensa Rust 1.94.x / 1.95.x) fail to
+// compile release builds for the Xtensa target: the backend can't select
+// XtensaISD::PCREL_WRAPPER for a constant-pool string reference and aborts
+// with `rustc-LLVM ERROR: Cannot select`. LLVM 20 (Xtensa Rust 1.93.0.0) is
+// the last good version. Turn that cryptic crash into an actionable message.
+// Revisit the version bound once esp-rs ships a fixed LLVM 21.
+fn check_llvm_version() {
+    let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    let output = match std::process::Command::new(&rustc)
+        .args(["--version", "--verbose"])
+        .output()
+    {
+        Ok(output) => output,
+        // Can't probe rustc; don't block the build over it.
+        Err(_) => return,
+    };
+
+    let major = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .find_map(|line| line.strip_prefix("LLVM version:"))
+        .and_then(|version| version.trim().split('.').next())
+        .and_then(|major| major.parse::<u32>().ok());
+
+    if let Some(major) = major {
+        if major >= 21 {
+            eprintln!();
+            eprintln!("This esp toolchain bundles LLVM {major}, which miscompiles optimized");
+            eprintln!("Xtensa builds (XtensaISD::PCREL_WRAPPER cannot be selected). Install the");
+            eprintln!("last known-good toolchain:");
+            eprintln!();
+            eprintln!("    espup install --toolchain-version 1.93.0.0");
+            eprintln!();
+            std::process::exit(1);
+        }
+    }
 }
 
 fn linker_be_nice() {


### PR DESCRIPTION
esp toolchains 1.94.x and 1.95.x ship LLVM 21, which fails to compile
release builds for the Xtensa target. `cargo build --release` aborts with
`rustc-LLVM ERROR: Cannot select ... XtensaISD::PCREL_WRAPPER`. Version
1.93.0.0, the last release on LLVM 20, builds correctly. See #16 for the
full writeup and upstream references (esp-rs/rust#277, candidate fix
espressif/llvm-project@39a5993).

Two commits, to be reverted once a fixed LLVM 21 toolchain is confirmed:

- `docs(readme)`: pin the espup install step to 1.93.0.0 and note the
  reason.
- `build`: check the bundled LLVM version in the build script and stop the
  build with install instructions when it is 21 or newer, catching an
  accidental toolchain update.
