### PR TITLE
Update BitaxeBonanza raw for Bridge protocol 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ When connected, this firmware creates two serial ports:
 ### Data Serial
 - Second serial port
 - All data is passed through in both directions.
-- The USB CDC baudrate is mirrored onto ESP32 `UART1`.
+- The USB CDC baudrate setting is ignored; host tools do not need to request a particular baudrate.
 - On bitaxeBonanza, this UART connects to the RP2040 bridge data UART on ESP32 `TX GPIO17` and `RX GPIO18`.
-- The RP2040 bridge expects this link to run at `5000000` baud.
+- The physical ESP32-to-RP2040 link is fixed at `2000000` baud, as required by current `bonanza-bridge-fw`.
 
 
 ### Control Serial
@@ -133,6 +133,18 @@ Example
 - Read `asic_trip`: `06 00 00 00 06 03`
 
 On bitaxeBonanza, these GPIO commands are forwarded to the RP2040 bridge. The `RST_N` compatibility alias is translated to the RP2040 `asic_rst` command so existing host tools can keep using command `0x00`.
+
+`bitaxe-raw-bonanza` transparently owns the bridge safety lease. The first request that can make the board unsafe checks bridge compatibility, clears a recoverable latched fault while outputs are safe, arms the lease, and then performs the original command. An internal task renews the lease every 250 ms. Existing clients do not send arm or heartbeat commands. Closing the control serial port asserts ASIC reset, disables 5 V, forces the fan to 100%, and disarms the lease.
+
+**Bridge diagnostics**
+
+Read-only bridge system commands are available on page `0x00`:
+
+- firmware and protocol info: `0x01`
+- receive overflow counters: `0x02`
+- safety status: `0x10`
+
+Lease mutation commands are deliberately internal to the firmware.
 
 **ADC**
 

--- a/src/bridge_protocol.rs
+++ b/src/bridge_protocol.rs
@@ -193,6 +193,14 @@ pub fn decode_info(payload: &[u8]) -> Result<BridgeInfo<'_>, ProtocolError> {
     })
 }
 
+pub fn decode_gpio_level(payload: &[u8]) -> Result<bool, ProtocolError> {
+    match payload {
+        [0] => Ok(false),
+        [1] => Ok(true),
+        _ => Err(ProtocolError::InvalidResponse),
+    }
+}
+
 pub fn decode_safety_status(payload: &[u8]) -> Result<SafetyStatus, ProtocolError> {
     if payload.len() != SAFETY_STATUS_LENGTH
         || payload[0] != SAFETY_STATUS_SCHEMA_VERSION
@@ -296,6 +304,14 @@ mod tests {
 
         let invalid = [1, 1, 0, 1, b'\n'];
         assert_eq!(decode_info(&invalid), Err(ProtocolError::InvalidResponse));
+    }
+
+    #[test]
+    fn gpio_levels_are_single_canonical_boolean_bytes() {
+        assert_eq!(decode_gpio_level(&[0]), Ok(false));
+        assert_eq!(decode_gpio_level(&[1]), Ok(true));
+        assert_eq!(decode_gpio_level(&[2]), Err(ProtocolError::InvalidResponse));
+        assert_eq!(decode_gpio_level(&[0, 1]), Err(ProtocolError::InvalidResponse));
     }
 
     #[test]

--- a/src/bridge_protocol.rs
+++ b/src/bridge_protocol.rs
@@ -4,6 +4,7 @@ pub const VERSION_MAX_LENGTH: usize = 63;
 
 pub const SAFETY_STATUS_SCHEMA_VERSION: u8 = 1;
 pub const SAFETY_STATUS_LENGTH: usize = 17;
+pub const SAFETY_STAGE_TRIP_LATCH: u8 = 2;
 
 pub const PAGE_SYSTEM: u8 = 0x00;
 pub const SYSTEM_GET_INFO: u8 = 0x01;
@@ -85,6 +86,13 @@ pub struct SafetyStatus {
     pub trip_input_asserted: bool,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LeasePreparation {
+    Adopt,
+    Arm,
+    ClearThenArm,
+}
+
 impl SafetyStatus {
     pub const fn outputs_safe(self) -> bool {
         !self.five_volt_enabled && self.asic_reset_asserted && self.fan_percent == 100
@@ -100,6 +108,22 @@ impl SafetyStatus {
 
     pub fn lease_valid(self) -> bool {
         self.state == SafetyState::Controlled && self.lease_remaining_ms > 0 && (self.evidence & EVIDENCE_LEASE_VALID) != 0
+    }
+
+    pub fn lease_preparation(self) -> Result<LeasePreparation, ProtocolError> {
+        if self.stage != SAFETY_STAGE_TRIP_LATCH {
+            return Err(ProtocolError::Denied);
+        }
+        if !self.trip_clear() {
+            return Err(ProtocolError::Fault);
+        }
+
+        match self.state {
+            SafetyState::Controlled if self.lease_valid() && self.fault_clear() => Ok(LeasePreparation::Adopt),
+            SafetyState::SafeOff if self.outputs_safe() && self.fault_clear() => Ok(LeasePreparation::Arm),
+            SafetyState::FaultLatched if self.outputs_safe() => Ok(LeasePreparation::ClearThenArm),
+            _ => Err(ProtocolError::Fault),
+        }
     }
 }
 
@@ -285,12 +309,11 @@ mod tests {
         let mut controlled = safe_status_payload();
         controlled[2] = 1;
         controlled[4] = 1;
-        controlled[8] = EVIDENCE_LEASE_VALID as u8 | EVIDENCE_TRIP_CLEAR as u8 | EVIDENCE_FAULT_CLEAR as u8;
+        controlled[8] = EVIDENCE_OUTPUTS_SAFE as u8 | EVIDENCE_LEASE_VALID as u8 | EVIDENCE_TRIP_CLEAR as u8 | EVIDENCE_FAULT_CLEAR as u8;
         controlled[10..14].copy_from_slice(&1_750u32.to_le_bytes());
-        controlled[14] = 0x04;
         let status = decode_safety_status(&controlled).unwrap();
         assert!(status.lease_valid());
-        assert!(!status.outputs_safe());
+        assert!(status.outputs_safe());
     }
 
     #[test]
@@ -302,5 +325,37 @@ mod tests {
         let mut payload = safe_status_payload();
         payload[2] = SafetyState::FaultLatched as u8;
         assert_eq!(decode_safety_status(&payload), Err(ProtocolError::InvalidResponse));
+    }
+
+    #[test]
+    fn lease_preparation_only_accepts_coherent_trip_latched_states() {
+        let safe = decode_safety_status(&safe_status_payload()).unwrap();
+        assert_eq!(safe.lease_preparation(), Ok(LeasePreparation::Arm));
+
+        let mut controlled = safe_status_payload();
+        controlled[2] = SafetyState::Controlled as u8;
+        controlled[4] = 1;
+        controlled[8] |= EVIDENCE_LEASE_VALID as u8;
+        controlled[10..14].copy_from_slice(&1_750u32.to_le_bytes());
+        let controlled = decode_safety_status(&controlled).unwrap();
+        assert_eq!(controlled.lease_preparation(), Ok(LeasePreparation::Adopt));
+
+        let mut faulted = safe_status_payload();
+        faulted[2] = SafetyState::FaultLatched as u8;
+        faulted[3] = SafetyFault::LeaseExpired as u8;
+        faulted[4] = 0x80;
+        faulted[5] = 0x82;
+        faulted[8] &= !EVIDENCE_FAULT_CLEAR as u8;
+        let faulted = decode_safety_status(&faulted).unwrap();
+        assert_eq!(faulted.lease_preparation(), Ok(LeasePreparation::ClearThenArm));
+
+        let mut active_trip = faulted;
+        active_trip.trip_input_asserted = true;
+        active_trip.evidence &= !EVIDENCE_TRIP_CLEAR;
+        assert_eq!(active_trip.lease_preparation(), Err(ProtocolError::Fault));
+
+        let mut weak_stage = safe;
+        weak_stage.stage = 1;
+        assert_eq!(weak_stage.lease_preparation(), Err(ProtocolError::Denied));
     }
 }

--- a/src/bridge_protocol.rs
+++ b/src/bridge_protocol.rs
@@ -1,0 +1,306 @@
+pub const INFO_SCHEMA_VERSION: u8 = 1;
+pub const PROTOCOL_MAJOR: u8 = 1;
+pub const VERSION_MAX_LENGTH: usize = 63;
+
+pub const SAFETY_STATUS_SCHEMA_VERSION: u8 = 1;
+pub const SAFETY_STATUS_LENGTH: usize = 17;
+
+pub const PAGE_SYSTEM: u8 = 0x00;
+pub const SYSTEM_GET_INFO: u8 = 0x01;
+pub const SYSTEM_GET_RX_STATS: u8 = 0x02;
+pub const SYSTEM_GET_SAFETY_STATUS: u8 = 0x10;
+pub const SYSTEM_ARM_SAFETY_LEASE: u8 = 0x11;
+pub const SYSTEM_SAFETY_HEARTBEAT: u8 = 0x12;
+pub const SYSTEM_CLEAR_SAFETY_FAULT: u8 = 0x13;
+pub const SYSTEM_DISARM_SAFETY_LEASE: u8 = 0x14;
+
+pub const PAGE_GPIO: u8 = 0x06;
+pub const GPIO_5V_ENABLE: u8 = 0x01;
+pub const GPIO_ASIC_RESET: u8 = 0x02;
+pub const GPIO_ASIC_TRIP: u8 = 0x03;
+
+pub const PAGE_FAN: u8 = 0x09;
+pub const FAN_SET_SPEED: u8 = 0x10;
+pub const FAN_GET_TACH: u8 = 0x20;
+
+pub const EVIDENCE_OUTPUTS_SAFE: u16 = 1 << 0;
+pub const EVIDENCE_LEASE_VALID: u16 = 1 << 1;
+pub const EVIDENCE_TRIP_CLEAR: u16 = 1 << 2;
+pub const EVIDENCE_FAULT_CLEAR: u16 = 1 << 3;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProtocolError {
+    BufferTooSmall,
+    InvalidFrame,
+    InvalidResponse,
+    Timeout,
+    InvalidCommand,
+    Denied,
+    Fault,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BridgeInfo<'a> {
+    pub protocol_major: u8,
+    pub protocol_minor: u8,
+    pub version: &'a str,
+}
+
+impl BridgeInfo<'_> {
+    pub const fn is_compatible(self) -> bool {
+        self.protocol_major == PROTOCOL_MAJOR
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum SafetyState {
+    SafeOff = 0,
+    Controlled = 1,
+    FaultLatched = 2,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum SafetyFault {
+    None = 0,
+    LeaseExpired = 1,
+    AsicTrip = 2,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SafetyStatus {
+    pub stage: u8,
+    pub state: SafetyState,
+    pub fault: SafetyFault,
+    pub runtime_verdict: u8,
+    pub production_verdict: u8,
+    pub capabilities: u16,
+    pub evidence: u16,
+    pub lease_remaining_ms: u32,
+    pub five_volt_enabled: bool,
+    pub asic_reset_asserted: bool,
+    pub fan_full: bool,
+    pub fan_percent: u8,
+    pub trip_input_asserted: bool,
+}
+
+impl SafetyStatus {
+    pub const fn outputs_safe(self) -> bool {
+        !self.five_volt_enabled && self.asic_reset_asserted && self.fan_percent == 100
+    }
+
+    pub const fn trip_clear(self) -> bool {
+        !self.trip_input_asserted && (self.evidence & EVIDENCE_TRIP_CLEAR) != 0
+    }
+
+    pub fn fault_clear(self) -> bool {
+        self.fault == SafetyFault::None && (self.evidence & EVIDENCE_FAULT_CLEAR) != 0
+    }
+
+    pub fn lease_valid(self) -> bool {
+        self.state == SafetyState::Controlled && self.lease_remaining_ms > 0 && (self.evidence & EVIDENCE_LEASE_VALID) != 0
+    }
+}
+
+pub fn encode_request(id: u8, page: u8, command: u8, payload: &[u8], output: &mut [u8]) -> Result<usize, ProtocolError> {
+    let frame_length = payload.len().checked_add(6).ok_or(ProtocolError::BufferTooSmall)?;
+    if frame_length > u16::MAX as usize || frame_length > output.len() {
+        return Err(ProtocolError::BufferTooSmall);
+    }
+
+    output[0..2].copy_from_slice(&(frame_length as u16).to_le_bytes());
+    output[2] = id;
+    output[3] = 0;
+    output[4] = page;
+    output[5] = command;
+    output[6..frame_length].copy_from_slice(payload);
+    Ok(frame_length)
+}
+
+pub fn declared_frame_length(frame: &[u8], maximum: usize) -> Result<Option<usize>, ProtocolError> {
+    if frame.len() < 2 {
+        return Ok(None);
+    }
+
+    let frame_length = u16::from_le_bytes([frame[0], frame[1]]) as usize;
+    if !(3..=maximum).contains(&frame_length) {
+        return Err(ProtocolError::InvalidFrame);
+    }
+    if frame.len() < frame_length {
+        return Ok(None);
+    }
+    Ok(Some(frame_length))
+}
+
+pub fn decode_response(expected_id: u8, frame: &[u8]) -> Result<&[u8], ProtocolError> {
+    let declared = declared_frame_length(frame, frame.len())?.ok_or(ProtocolError::InvalidFrame)?;
+    if declared != frame.len() || frame[2] != expected_id {
+        return Err(ProtocolError::InvalidResponse);
+    }
+
+    let payload = &frame[3..];
+    if payload.len() == 1 {
+        match payload[0] {
+            0x10 => return Err(ProtocolError::Timeout),
+            0x11 => return Err(ProtocolError::InvalidCommand),
+            0x12 => return Err(ProtocolError::Denied),
+            0x13 => return Err(ProtocolError::Fault),
+            _ => {}
+        }
+    }
+    Ok(payload)
+}
+
+pub fn decode_info(payload: &[u8]) -> Result<BridgeInfo<'_>, ProtocolError> {
+    if payload.len() < 4 || payload[0] != INFO_SCHEMA_VERSION || payload[3] == 0 || payload[3] as usize > VERSION_MAX_LENGTH || payload.len() != 4 + payload[3] as usize {
+        return Err(ProtocolError::InvalidResponse);
+    }
+
+    let version = core::str::from_utf8(&payload[4..]).map_err(|_| ProtocolError::InvalidResponse)?;
+    if !version.bytes().all(|byte| (0x20..=0x7e).contains(&byte)) {
+        return Err(ProtocolError::InvalidResponse);
+    }
+
+    Ok(BridgeInfo {
+        protocol_major: payload[1],
+        protocol_minor: payload[2],
+        version,
+    })
+}
+
+pub fn decode_safety_status(payload: &[u8]) -> Result<SafetyStatus, ProtocolError> {
+    if payload.len() != SAFETY_STATUS_LENGTH
+        || payload[0] != SAFETY_STATUS_SCHEMA_VERSION
+        || payload[1] > 2
+        || payload[2] > SafetyState::FaultLatched as u8
+        || payload[3] > SafetyFault::AsicTrip as u8
+        || payload[14] & !0x07 != 0
+        || payload[15] > 100
+        || payload[16] > 1
+    {
+        return Err(ProtocolError::InvalidResponse);
+    }
+
+    let state = match payload[2] {
+        0 => SafetyState::SafeOff,
+        1 => SafetyState::Controlled,
+        2 => SafetyState::FaultLatched,
+        _ => return Err(ProtocolError::InvalidResponse),
+    };
+    let fault = match payload[3] {
+        0 => SafetyFault::None,
+        1 => SafetyFault::LeaseExpired,
+        2 => SafetyFault::AsicTrip,
+        _ => return Err(ProtocolError::InvalidResponse),
+    };
+    let capabilities = u16::from_le_bytes([payload[6], payload[7]]);
+    let evidence = u16::from_le_bytes([payload[8], payload[9]]);
+    let lease_remaining_ms = u32::from_le_bytes([payload[10], payload[11], payload[12], payload[13]]);
+    let five_volt_enabled = payload[14] & 0x01 != 0;
+    let asic_reset_asserted = payload[14] & 0x02 != 0;
+    let fan_full = payload[14] & 0x04 != 0;
+    let fan_percent = payload[15];
+    let trip_input_asserted = payload[16] != 0;
+
+    if fan_full != (fan_percent == 100)
+        || ((evidence & EVIDENCE_OUTPUTS_SAFE) != 0) != (!five_volt_enabled && asic_reset_asserted && fan_percent == 100)
+        || ((evidence & EVIDENCE_TRIP_CLEAR) != 0) == trip_input_asserted
+        || ((evidence & EVIDENCE_FAULT_CLEAR) != 0) != (fault == SafetyFault::None)
+        || (state == SafetyState::FaultLatched) != (fault != SafetyFault::None)
+        || (state != SafetyState::Controlled && lease_remaining_ms != 0)
+    {
+        return Err(ProtocolError::InvalidResponse);
+    }
+
+    Ok(SafetyStatus {
+        stage: payload[1],
+        state,
+        fault,
+        runtime_verdict: payload[4],
+        production_verdict: payload[5],
+        capabilities,
+        evidence,
+        lease_remaining_ms,
+        five_volt_enabled,
+        asic_reset_asserted,
+        fan_full,
+        fan_percent,
+        trip_input_asserted,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn safe_status_payload() -> [u8; SAFETY_STATUS_LENGTH] {
+        [1, 2, 0, 0, 0, 0x81, 0x0f, 0, 0x0d, 0, 0, 0, 0, 0, 0x06, 100, 0]
+    }
+
+    #[test]
+    fn request_encoding_matches_bridge_wire_format() {
+        let mut output = [0u8; 16];
+        let length = encode_request(0x2a, PAGE_SYSTEM, SYSTEM_GET_INFO, &[], &mut output).unwrap();
+        assert_eq!(length, 6);
+        assert_eq!(&output[..length], &[6, 0, 0x2a, 0, 0, 1]);
+    }
+
+    #[test]
+    fn fragmented_and_complete_lengths_are_distinguished() {
+        assert_eq!(declared_frame_length(&[5], 260), Ok(None));
+        assert_eq!(declared_frame_length(&[5, 0, 1], 260), Ok(None));
+        assert_eq!(declared_frame_length(&[5, 0, 1, 2, 3], 260), Ok(Some(5)));
+        assert_eq!(declared_frame_length(&[2, 0], 260), Err(ProtocolError::InvalidFrame));
+    }
+
+    #[test]
+    fn response_errors_are_not_mistaken_for_payloads() {
+        assert_eq!(decode_response(7, &[4, 0, 7, 0x12]), Err(ProtocolError::Denied));
+        assert_eq!(decode_response(7, &[4, 0, 7, 0x13]), Err(ProtocolError::Fault));
+        assert_eq!(decode_response(8, &[4, 0, 7, 0]), Err(ProtocolError::InvalidResponse));
+    }
+
+    #[test]
+    fn info_requires_protocol_schema_and_printable_version() {
+        let payload = [1, 1, 0, 5, b'1', b'.', b'2', b'.', b'3'];
+        let info = decode_info(&payload).unwrap();
+        assert_eq!(info.protocol_major, 1);
+        assert_eq!(info.protocol_minor, 0);
+        assert_eq!(info.version, "1.2.3");
+        assert!(info.is_compatible());
+
+        let invalid = [1, 1, 0, 1, b'\n'];
+        assert_eq!(decode_info(&invalid), Err(ProtocolError::InvalidResponse));
+    }
+
+    #[test]
+    fn coherent_safe_and_controlled_statuses_decode() {
+        let safe = decode_safety_status(&safe_status_payload()).unwrap();
+        assert!(safe.outputs_safe());
+        assert!(safe.trip_clear());
+        assert!(safe.fault_clear());
+        assert!(!safe.lease_valid());
+
+        let mut controlled = safe_status_payload();
+        controlled[2] = 1;
+        controlled[4] = 1;
+        controlled[8] = EVIDENCE_LEASE_VALID as u8 | EVIDENCE_TRIP_CLEAR as u8 | EVIDENCE_FAULT_CLEAR as u8;
+        controlled[10..14].copy_from_slice(&1_750u32.to_le_bytes());
+        controlled[14] = 0x04;
+        let status = decode_safety_status(&controlled).unwrap();
+        assert!(status.lease_valid());
+        assert!(!status.outputs_safe());
+    }
+
+    #[test]
+    fn incoherent_safety_evidence_is_rejected() {
+        let mut payload = safe_status_payload();
+        payload[8] &= !EVIDENCE_OUTPUTS_SAFE as u8;
+        assert_eq!(decode_safety_status(&payload), Err(ProtocolError::InvalidResponse));
+
+        let mut payload = safe_status_payload();
+        payload[2] = SafetyState::FaultLatched as u8;
+        assert_eq!(decode_safety_status(&payload), Err(ProtocolError::InvalidResponse));
+    }
+}

--- a/src/control/bridge.rs
+++ b/src/control/bridge.rs
@@ -3,6 +3,7 @@ use embedded_io_async::Write;
 use heapless::Vec;
 
 use super::CommandError;
+use crate::bridge_protocol::{self, ProtocolError};
 
 const UART_TIMEOUT: Duration = Duration::from_millis(1000);
 const FRAME_BUF_LEN: usize = 512;
@@ -11,42 +12,71 @@ pub struct BridgeControl {
     uart: crate::BridgeControlUart,
     rx_buf: [u8; FRAME_BUF_LEN],
     rx_len: usize,
+    next_id: u8,
 }
 
 impl BridgeControl {
     pub fn new(uart: crate::BridgeControlUart) -> Self {
-        Self { uart, rx_buf: [0; FRAME_BUF_LEN], rx_len: 0 }
+        Self {
+            uart,
+            rx_buf: [0; FRAME_BUF_LEN],
+            rx_len: 0,
+            next_id: 0,
+        }
     }
 
-    pub async fn transact(&mut self, id: u8, bus: u8, page: u8, command: u8, data: &[u8]) -> Result<Vec<u8, 256>, CommandError> {
-        let mut request = Vec::<u8, 260>::new();
-        request.extend_from_slice(&[0, 0, id, bus, page, command]).map_err(|_| CommandError::BufferOverflow)?;
-        request.extend_from_slice(data).map_err(|_| CommandError::BufferOverflow)?;
+    pub async fn transact(&mut self, page: u8, command: u8, data: &[u8]) -> Result<Vec<u8, 256>, CommandError> {
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1);
 
-        let len = (request.len() as u16).to_le_bytes();
-        request[0..2].copy_from_slice(&len);
+        let mut request = [0u8; 260];
+        let request_len = bridge_protocol::encode_request(id, page, command, data, &mut request).map_err(CommandError::from_protocol)?;
 
-        self.uart.write_all(&request).await.map_err(|_| CommandError::Message("Bridge UART Write Error"))?;
+        self.uart.write_all(&request[..request_len]).await.map_err(|_| CommandError::Message("Bridge UART Write Error"))?;
         self.uart.flush_async().await.map_err(|_| CommandError::Message("Bridge UART Flush Error"))?;
 
-        let response = with_timeout(UART_TIMEOUT, self.read_frame()).await.map_err(|_| CommandError::Timeout)??;
-        if response.len() < 3 || response[2] != id {
-            return Err(CommandError::Message("Bridge UART Response Error"));
+        let result = with_timeout(UART_TIMEOUT, self.read_response(id)).await;
+        match result {
+            Ok(result) => result,
+            Err(_) => {
+                self.rx_len = 0;
+                Err(CommandError::Timeout)
+            }
         }
-
-        Vec::from_slice(&response[3..]).map_err(|_| CommandError::BufferOverflow)
     }
 
-    async fn read_frame(&mut self) -> Result<Vec<u8, 260>, CommandError> {
+    async fn read_response(&mut self, expected_id: u8) -> Result<Vec<u8, 256>, CommandError> {
         loop {
-            if let Some(frame_len) = try_extract_frame_len(&self.rx_buf[..self.rx_len])? {
-                let frame = Vec::from_slice(&self.rx_buf[..frame_len]).map_err(|_| CommandError::BufferOverflow)?;
+            let frame_length = match bridge_protocol::declared_frame_length(&self.rx_buf[..self.rx_len], FRAME_BUF_LEN) {
+                Ok(frame_length) => frame_length,
+                Err(error) => {
+                    self.rx_len = 0;
+                    return Err(CommandError::from_protocol(error));
+                }
+            };
+            if let Some(frame_len) = frame_length {
+                let response_id = self.rx_buf[2];
+                let decoded = if response_id == expected_id {
+                    bridge_protocol::decode_response(expected_id, &self.rx_buf[..frame_len]).map(Vec::from_slice)
+                } else {
+                    Err(ProtocolError::InvalidResponse)
+                };
+
                 let excess = self.rx_len - frame_len;
                 if excess > 0 {
                     self.rx_buf.copy_within(frame_len..self.rx_len, 0);
                 }
                 self.rx_len = excess;
-                return Ok(frame);
+
+                if response_id != expected_id {
+                    continue;
+                }
+                return decoded.map_err(CommandError::from_protocol)?.map_err(|_| CommandError::BufferOverflow);
+            }
+
+            if self.rx_len == FRAME_BUF_LEN {
+                self.rx_len = 0;
+                return Err(CommandError::Invalid);
             }
 
             let n = self.uart.read_async(&mut self.rx_buf[self.rx_len..]).await.map_err(|_| CommandError::Message("Bridge UART Read Error"))?;
@@ -56,21 +86,4 @@ impl BridgeControl {
             self.rx_len += n;
         }
     }
-}
-
-fn try_extract_frame_len(buf: &[u8]) -> Result<Option<usize>, CommandError> {
-    if buf.len() < 2 {
-        return Ok(None);
-    }
-
-    let frame_len = u16::from_le_bytes([buf[0], buf[1]]) as usize;
-    if !(3..=FRAME_BUF_LEN).contains(&frame_len) {
-        return Err(CommandError::Invalid);
-    }
-
-    if buf.len() < frame_len {
-        return Ok(None);
-    }
-
-    Ok(Some(frame_len))
 }

--- a/src/control/bridge.rs
+++ b/src/control/bridge.rs
@@ -188,6 +188,28 @@ impl BridgeManager {
                 self.fail_safe().await;
                 return Err(error);
             }
+
+            // Legacy clients may repeat an enable after reset has already been
+            // released. The strict Bridge rejects that sequence even when 5 V
+            // is already enabled, so treat a matching level as an idempotent
+            // success without retransmitting the unsafe write.
+            let current = match self.control.transact(bridge_protocol::PAGE_GPIO, command, &[]).await {
+                Ok(current) => current,
+                Err(error) => {
+                    self.fail_safe().await;
+                    return Err(error);
+                }
+            };
+            let current_level = match bridge_protocol::decode_gpio_level(&current) {
+                Ok(current_level) => current_level,
+                Err(error) => {
+                    self.fail_safe().await;
+                    return Err(CommandError::from_protocol(error));
+                }
+            };
+            if Some(current_level) == level {
+                return Ok(current);
+            }
         }
 
         let payload = level.map(|level| [level as u8]);

--- a/src/control/bridge.rs
+++ b/src/control/bridge.rs
@@ -20,6 +20,7 @@ static REPLY_CHANNEL: Channel<CriticalSectionRawMutex, ReplyEnvelope, REQUEST_QU
 
 #[derive(defmt::Format)]
 enum Request {
+    System { command: u8 },
     Gpio { command: u8, level: Option<bool> },
     Fan { command: u8, speed: Option<u8> },
     Shutdown,
@@ -53,6 +54,10 @@ async fn request(request: Request) -> Result<Vec<u8, 256>, CommandError> {
 
 pub async fn gpio(command: u8, level: Option<bool>) -> Result<Vec<u8, 256>, CommandError> {
     request(Request::Gpio { command, level }).await
+}
+
+pub async fn system(command: u8) -> Result<Vec<u8, 256>, CommandError> {
+    request(Request::System { command }).await
 }
 
 pub async fn fan(command: u8, speed: Option<u8>) -> Result<Vec<u8, 256>, CommandError> {
@@ -158,6 +163,7 @@ impl BridgeManager {
 
     async fn handle(&mut self, request: Request) -> Result<Vec<u8, 256>, CommandError> {
         match request {
+            Request::System { command } => self.handle_system(command).await,
             Request::Gpio { command, level } => self.handle_gpio(command, level).await,
             Request::Fan { command, speed } => self.handle_fan(command, speed).await,
             Request::Shutdown => {
@@ -165,6 +171,14 @@ impl BridgeManager {
                 Ok(Vec::new())
             }
         }
+    }
+
+    async fn handle_system(&mut self, command: u8) -> Result<Vec<u8, 256>, CommandError> {
+        let result = self.control.transact(bridge_protocol::PAGE_SYSTEM, command, &[]).await;
+        if self.lease_active && result.is_err() {
+            self.fail_safe().await;
+        }
+        result
     }
 
     async fn handle_gpio(&mut self, command: u8, level: Option<bool>) -> Result<Vec<u8, 256>, CommandError> {

--- a/src/control/bridge.rs
+++ b/src/control/bridge.rs
@@ -1,12 +1,67 @@
-use embassy_time::{with_timeout, Duration};
+use core::sync::atomic::{AtomicU8, Ordering};
+
+use embassy_futures::select::{select, Either};
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Channel};
+use embassy_time::{with_timeout, Duration, Ticker};
 use embedded_io_async::Write;
 use heapless::Vec;
 
 use super::CommandError;
-use crate::bridge_protocol::{self, ProtocolError};
+use crate::bridge_protocol::{self, LeasePreparation, ProtocolError, SafetyStatus};
 
 const UART_TIMEOUT: Duration = Duration::from_millis(1000);
 const FRAME_BUF_LEN: usize = 512;
+const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(250);
+const REQUEST_QUEUE_LEN: usize = 8;
+
+static NEXT_REQUEST_ID: AtomicU8 = AtomicU8::new(0);
+static REQUEST_CHANNEL: Channel<CriticalSectionRawMutex, RequestEnvelope, REQUEST_QUEUE_LEN> = Channel::new();
+static REPLY_CHANNEL: Channel<CriticalSectionRawMutex, ReplyEnvelope, REQUEST_QUEUE_LEN> = Channel::new();
+
+#[derive(defmt::Format)]
+enum Request {
+    Gpio { command: u8, level: Option<bool> },
+    Fan { command: u8, speed: Option<u8> },
+    Shutdown,
+}
+
+#[derive(defmt::Format)]
+struct RequestEnvelope {
+    id: u8,
+    request: Request,
+}
+
+struct ReplyEnvelope {
+    id: u8,
+    result: Result<Vec<u8, 256>, CommandError>,
+}
+
+async fn request(request: Request) -> Result<Vec<u8, 256>, CommandError> {
+    let id = NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
+    REQUEST_CHANNEL.send(RequestEnvelope { id, request }).await;
+
+    // The control task is the sole regular caller. IDs also make cancellation
+    // safe: a reply abandoned by a disconnected USB client is skipped by the
+    // next request instead of being mistaken for its result.
+    loop {
+        let reply = REPLY_CHANNEL.receive().await;
+        if reply.id == id {
+            return reply.result;
+        }
+    }
+}
+
+pub async fn gpio(command: u8, level: Option<bool>) -> Result<Vec<u8, 256>, CommandError> {
+    request(Request::Gpio { command, level }).await
+}
+
+pub async fn fan(command: u8, speed: Option<u8>) -> Result<Vec<u8, 256>, CommandError> {
+    request(Request::Fan { command, speed }).await
+}
+
+pub async fn shutdown() {
+    let _ = request(Request::Shutdown).await;
+}
 
 pub struct BridgeControl {
     uart: crate::BridgeControlUart,
@@ -84,6 +139,153 @@ impl BridgeControl {
                 continue;
             }
             self.rx_len += n;
+        }
+    }
+}
+
+struct BridgeManager {
+    control: BridgeControl,
+    lease_active: bool,
+}
+
+impl BridgeManager {
+    fn new(uart: crate::BridgeControlUart) -> Self {
+        Self {
+            control: BridgeControl::new(uart),
+            lease_active: false,
+        }
+    }
+
+    async fn handle(&mut self, request: Request) -> Result<Vec<u8, 256>, CommandError> {
+        match request {
+            Request::Gpio { command, level } => self.handle_gpio(command, level).await,
+            Request::Fan { command, speed } => self.handle_fan(command, speed).await,
+            Request::Shutdown => {
+                self.fail_safe().await;
+                Ok(Vec::new())
+            }
+        }
+    }
+
+    async fn handle_gpio(&mut self, command: u8, level: Option<bool>) -> Result<Vec<u8, 256>, CommandError> {
+        let unsafe_transition = matches!((command, level), (bridge_protocol::GPIO_5V_ENABLE, Some(true)) | (bridge_protocol::GPIO_ASIC_RESET, Some(true)));
+        if unsafe_transition {
+            if let Err(error) = self.ensure_controlled().await {
+                self.fail_safe().await;
+                return Err(error);
+            }
+        }
+
+        let payload = level.map(|level| [level as u8]);
+        let result = self.control.transact(bridge_protocol::PAGE_GPIO, command, payload.as_ref().map_or(&[], |value| value.as_slice())).await;
+
+        if result.is_err() {
+            self.fail_safe().await;
+        } else if command == bridge_protocol::GPIO_5V_ENABLE && level == Some(false) {
+            self.disarm().await;
+        }
+        result
+    }
+
+    async fn handle_fan(&mut self, command: u8, speed: Option<u8>) -> Result<Vec<u8, 256>, CommandError> {
+        if command == bridge_protocol::FAN_SET_SPEED && speed.is_some_and(|speed| speed < 100) {
+            if let Err(error) = self.ensure_controlled().await {
+                self.fail_safe().await;
+                return Err(error);
+            }
+        }
+
+        let payload = speed.map(|speed| [speed]);
+        let result = self.control.transact(bridge_protocol::PAGE_FAN, command, payload.as_ref().map_or(&[], |value| value.as_slice())).await;
+        if result.is_err() {
+            self.fail_safe().await;
+        }
+        result
+    }
+
+    async fn ensure_controlled(&mut self) -> Result<(), CommandError> {
+        if self.lease_active {
+            return Ok(());
+        }
+
+        let info_payload = self.control.transact(bridge_protocol::PAGE_SYSTEM, bridge_protocol::SYSTEM_GET_INFO, &[]).await?;
+        let info = bridge_protocol::decode_info(&info_payload).map_err(CommandError::from_protocol)?;
+        if !info.is_compatible() {
+            return Err(CommandError::Denied);
+        }
+
+        let mut status = self.safety_command(bridge_protocol::SYSTEM_GET_SAFETY_STATUS).await?;
+        match status.lease_preparation().map_err(CommandError::from_protocol)? {
+            LeasePreparation::Adopt => {}
+            LeasePreparation::Arm => {
+                status = self.safety_command(bridge_protocol::SYSTEM_ARM_SAFETY_LEASE).await?;
+            }
+            LeasePreparation::ClearThenArm => {
+                status = self.safety_command(bridge_protocol::SYSTEM_CLEAR_SAFETY_FAULT).await?;
+                if status.lease_preparation().map_err(CommandError::from_protocol)? != LeasePreparation::Arm {
+                    return Err(CommandError::Fault);
+                }
+                status = self.safety_command(bridge_protocol::SYSTEM_ARM_SAFETY_LEASE).await?;
+            }
+        }
+
+        if !status.lease_valid() || !status.trip_clear() || !status.fault_clear() {
+            return Err(CommandError::Fault);
+        }
+        self.lease_active = true;
+        Ok(())
+    }
+
+    async fn heartbeat(&mut self) -> Result<(), CommandError> {
+        if !self.lease_active {
+            return Ok(());
+        }
+
+        let status = self.safety_command(bridge_protocol::SYSTEM_SAFETY_HEARTBEAT).await?;
+        if !status.lease_valid() || !status.trip_clear() || !status.fault_clear() {
+            return Err(CommandError::Fault);
+        }
+        Ok(())
+    }
+
+    async fn safety_command(&mut self, command: u8) -> Result<SafetyStatus, CommandError> {
+        let payload = self.control.transact(bridge_protocol::PAGE_SYSTEM, command, &[]).await?;
+        bridge_protocol::decode_safety_status(&payload).map_err(CommandError::from_protocol)
+    }
+
+    async fn disarm(&mut self) {
+        let _ = self.safety_command(bridge_protocol::SYSTEM_DISARM_SAFETY_LEASE).await;
+        self.lease_active = false;
+    }
+
+    async fn fail_safe(&mut self) {
+        self.lease_active = false;
+        let _ = self.control.transact(bridge_protocol::PAGE_GPIO, bridge_protocol::GPIO_ASIC_RESET, &[0]).await;
+        let _ = self.control.transact(bridge_protocol::PAGE_GPIO, bridge_protocol::GPIO_5V_ENABLE, &[0]).await;
+        let _ = self.control.transact(bridge_protocol::PAGE_FAN, bridge_protocol::FAN_SET_SPEED, &[100]).await;
+        let _ = self.control.transact(bridge_protocol::PAGE_SYSTEM, bridge_protocol::SYSTEM_DISARM_SAFETY_LEASE, &[]).await;
+    }
+}
+
+#[embassy_executor::task]
+pub async fn manager_task(uart: crate::BridgeControlUart) -> ! {
+    let mut manager = BridgeManager::new(uart);
+    let mut heartbeat_ticker = Ticker::every(HEARTBEAT_INTERVAL);
+
+    loop {
+        match select(REQUEST_CHANNEL.receive(), heartbeat_ticker.next()).await {
+            Either::First(envelope) => {
+                if manager.heartbeat().await.is_err() {
+                    manager.fail_safe().await;
+                }
+                let result = manager.handle(envelope.request).await;
+                REPLY_CHANNEL.send(ReplyEnvelope { id: envelope.id, result }).await;
+            }
+            Either::Second(()) => {
+                if manager.heartbeat().await.is_err() {
+                    manager.fail_safe().await;
+                }
+            }
         }
     }
 }

--- a/src/control/fan.rs
+++ b/src/control/fan.rs
@@ -1,6 +1,7 @@
 use heapless::Vec;
 
 use super::CommandError;
+use crate::bridge_protocol;
 
 #[derive(defmt::Format)]
 pub enum Command {
@@ -21,8 +22,8 @@ impl Command {
 impl super::ControllerCommand for Command {
     async fn handle(&self, controller: &mut super::Controller) -> Result<Vec<u8, 256>, CommandError> {
         match self {
-            Command::SetSpeed(speed) => controller.bridge.transact(0, 0, 0x09, 0x10, &[*speed]).await,
-            Command::GetTach => controller.bridge.transact(0, 0, 0x09, 0x20, &[]).await,
+            Command::SetSpeed(speed) => controller.bridge.transact(bridge_protocol::PAGE_FAN, bridge_protocol::FAN_SET_SPEED, &[*speed]).await,
+            Command::GetTach => controller.bridge.transact(bridge_protocol::PAGE_FAN, bridge_protocol::FAN_GET_TACH, &[]).await,
         }
     }
 }

--- a/src/control/fan.rs
+++ b/src/control/fan.rs
@@ -20,10 +20,10 @@ impl Command {
 }
 
 impl super::ControllerCommand for Command {
-    async fn handle(&self, controller: &mut super::Controller) -> Result<Vec<u8, 256>, CommandError> {
+    async fn handle(&self, _controller: &mut super::Controller) -> Result<Vec<u8, 256>, CommandError> {
         match self {
-            Command::SetSpeed(speed) => controller.bridge.transact(bridge_protocol::PAGE_FAN, bridge_protocol::FAN_SET_SPEED, &[*speed]).await,
-            Command::GetTach => controller.bridge.transact(bridge_protocol::PAGE_FAN, bridge_protocol::FAN_GET_TACH, &[]).await,
+            Command::SetSpeed(speed) => super::bridge::fan(bridge_protocol::FAN_SET_SPEED, Some(*speed)).await,
+            Command::GetTach => super::bridge::fan(bridge_protocol::FAN_GET_TACH, None).await,
         }
     }
 }

--- a/src/control/gpio.rs
+++ b/src/control/gpio.rs
@@ -1,4 +1,5 @@
 use super::CommandError;
+use crate::bridge_protocol;
 use esp_hal::gpio::{Input, Level, Output};
 use heapless::Vec;
 
@@ -45,13 +46,13 @@ impl super::ControllerCommand for Command {
     async fn handle(&self, controller: &mut super::Controller) -> Result<Vec<u8, 256>, CommandError> {
         match self {
             // Preserve the original bitaxe-raw-bonanza RST_N command ID and semantics.
-            Command::GetAsicResetn => controller.bridge.transact(0, 0, 0x06, 0x02, &[]).await,
-            Command::SetAsicResetn { level } => controller.bridge.transact(0, 0, 0x06, 0x02, &[*level as u8]).await,
-            Command::Get5vEn => controller.bridge.transact(0, 0, 0x06, 0x01, &[]).await,
-            Command::Set5vEn { level } => controller.bridge.transact(0, 0, 0x06, 0x01, &[*level as u8]).await,
-            Command::GetAsicRst => controller.bridge.transact(0, 0, 0x06, 0x02, &[]).await,
-            Command::SetAsicRst { level } => controller.bridge.transact(0, 0, 0x06, 0x02, &[*level as u8]).await,
-            Command::GetAsicTrip => controller.bridge.transact(0, 0, 0x06, 0x03, &[]).await,
+            Command::GetAsicResetn => controller.bridge.transact(bridge_protocol::PAGE_GPIO, bridge_protocol::GPIO_ASIC_RESET, &[]).await,
+            Command::SetAsicResetn { level } => controller.bridge.transact(bridge_protocol::PAGE_GPIO, bridge_protocol::GPIO_ASIC_RESET, &[*level as u8]).await,
+            Command::Get5vEn => controller.bridge.transact(bridge_protocol::PAGE_GPIO, bridge_protocol::GPIO_5V_ENABLE, &[]).await,
+            Command::Set5vEn { level } => controller.bridge.transact(bridge_protocol::PAGE_GPIO, bridge_protocol::GPIO_5V_ENABLE, &[*level as u8]).await,
+            Command::GetAsicRst => controller.bridge.transact(bridge_protocol::PAGE_GPIO, bridge_protocol::GPIO_ASIC_RESET, &[]).await,
+            Command::SetAsicRst { level } => controller.bridge.transact(bridge_protocol::PAGE_GPIO, bridge_protocol::GPIO_ASIC_RESET, &[*level as u8]).await,
+            Command::GetAsicTrip => controller.bridge.transact(bridge_protocol::PAGE_GPIO, bridge_protocol::GPIO_ASIC_TRIP, &[]).await,
             Command::GetVrEn => Ok(Vec::from_slice(&[controller.gpio.vr_en.is_set_high() as u8]).unwrap()),
             Command::SetVrEn { level } => {
                 controller.gpio.vr_en.set_level(Level::from(*level));

--- a/src/control/gpio.rs
+++ b/src/control/gpio.rs
@@ -1,5 +1,11 @@
 use super::CommandError;
+use esp_hal::gpio::{Input, Level, Output};
 use heapless::Vec;
+
+pub struct Pins<'d> {
+    pub vr_en: Output<'d>,
+    pub vr_pgood: Input<'d>,
+}
 
 #[derive(defmt::Format)]
 pub enum Command {
@@ -10,6 +16,9 @@ pub enum Command {
     SetAsicRst { level: bool },
     GetAsicRst,
     GetAsicTrip,
+    SetVrEn { level: bool },
+    GetVrEn,
+    GetVrPgood,
 }
 
 impl Command {
@@ -24,6 +33,9 @@ impl Command {
             [0x02] => Ok(Self::GetAsicRst),
             [0x02, level] => Ok(Self::SetAsicRst { level: *level > 0 }),
             [0x03] => Ok(Self::GetAsicTrip),
+            [0x04] => Ok(Self::GetVrEn),
+            [0x04, level] => Ok(Self::SetVrEn { level: *level > 0 }),
+            [0x05] => Ok(Self::GetVrPgood),
             _ => Err(CommandError::Invalid),
         }
     }
@@ -40,6 +52,12 @@ impl super::ControllerCommand for Command {
             Command::GetAsicRst => controller.bridge.transact(0, 0, 0x06, 0x02, &[]).await,
             Command::SetAsicRst { level } => controller.bridge.transact(0, 0, 0x06, 0x02, &[*level as u8]).await,
             Command::GetAsicTrip => controller.bridge.transact(0, 0, 0x06, 0x03, &[]).await,
+            Command::GetVrEn => Ok(Vec::from_slice(&[controller.gpio.vr_en.is_set_high() as u8]).unwrap()),
+            Command::SetVrEn { level } => {
+                controller.gpio.vr_en.set_level(Level::from(*level));
+                Ok(Vec::from_slice(&[*level as u8]).unwrap())
+            }
+            Command::GetVrPgood => Ok(Vec::from_slice(&[controller.gpio.vr_pgood.is_high() as u8]).unwrap()),
         }
     }
 }

--- a/src/control/gpio.rs
+++ b/src/control/gpio.rs
@@ -46,13 +46,13 @@ impl super::ControllerCommand for Command {
     async fn handle(&self, controller: &mut super::Controller) -> Result<Vec<u8, 256>, CommandError> {
         match self {
             // Preserve the original bitaxe-raw-bonanza RST_N command ID and semantics.
-            Command::GetAsicResetn => controller.bridge.transact(bridge_protocol::PAGE_GPIO, bridge_protocol::GPIO_ASIC_RESET, &[]).await,
-            Command::SetAsicResetn { level } => controller.bridge.transact(bridge_protocol::PAGE_GPIO, bridge_protocol::GPIO_ASIC_RESET, &[*level as u8]).await,
-            Command::Get5vEn => controller.bridge.transact(bridge_protocol::PAGE_GPIO, bridge_protocol::GPIO_5V_ENABLE, &[]).await,
-            Command::Set5vEn { level } => controller.bridge.transact(bridge_protocol::PAGE_GPIO, bridge_protocol::GPIO_5V_ENABLE, &[*level as u8]).await,
-            Command::GetAsicRst => controller.bridge.transact(bridge_protocol::PAGE_GPIO, bridge_protocol::GPIO_ASIC_RESET, &[]).await,
-            Command::SetAsicRst { level } => controller.bridge.transact(bridge_protocol::PAGE_GPIO, bridge_protocol::GPIO_ASIC_RESET, &[*level as u8]).await,
-            Command::GetAsicTrip => controller.bridge.transact(bridge_protocol::PAGE_GPIO, bridge_protocol::GPIO_ASIC_TRIP, &[]).await,
+            Command::GetAsicResetn => super::bridge::gpio(bridge_protocol::GPIO_ASIC_RESET, None).await,
+            Command::SetAsicResetn { level } => super::bridge::gpio(bridge_protocol::GPIO_ASIC_RESET, Some(*level)).await,
+            Command::Get5vEn => super::bridge::gpio(bridge_protocol::GPIO_5V_ENABLE, None).await,
+            Command::Set5vEn { level } => super::bridge::gpio(bridge_protocol::GPIO_5V_ENABLE, Some(*level)).await,
+            Command::GetAsicRst => super::bridge::gpio(bridge_protocol::GPIO_ASIC_RESET, None).await,
+            Command::SetAsicRst { level } => super::bridge::gpio(bridge_protocol::GPIO_ASIC_RESET, Some(*level)).await,
+            Command::GetAsicTrip => super::bridge::gpio(bridge_protocol::GPIO_ASIC_TRIP, None).await,
             Command::GetVrEn => Ok(Vec::from_slice(&[controller.gpio.vr_en.is_set_high() as u8]).unwrap()),
             Command::SetVrEn { level } => {
                 controller.gpio.vr_en.set_level(Level::from(*level));

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -111,6 +111,7 @@ pub struct Controller {
     tx: Sender<'static, super::UsbDriver>,
     i2c: super::I2cDriver,
     adc: adc::Pins<'static>,
+    gpio: gpio::Pins<'static>,
     bridge: bridge::BridgeControl,
 }
 
@@ -151,17 +152,13 @@ impl Controller {
 }
 
 #[embassy_executor::task]
-pub async fn usb_task(
-    class: CdcAcmClass<'static, super::UsbDriver>,
-    i2c: super::I2cDriver,
-    bridge_uart: crate::BridgeControlUart,
-    adc: adc::Pins<'static>,
-) -> ! {
+pub async fn usb_task(class: CdcAcmClass<'static, super::UsbDriver>, i2c: super::I2cDriver, bridge_uart: crate::BridgeControlUart, adc: adc::Pins<'static>, gpio: gpio::Pins<'static>) -> ! {
     let (tx, mut rx, mut _ctrl) = class.split_with_control();
     let mut controller = Controller {
         tx,
         i2c,
         adc,
+        gpio,
         bridge: bridge::BridgeControl::new(bridge_uart),
     };
 

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -132,7 +132,6 @@ pub struct Controller {
     i2c: super::I2cDriver,
     adc: adc::Pins<'static>,
     gpio: gpio::Pins<'static>,
-    bridge: bridge::BridgeControl,
 }
 
 pub trait ControllerCommand {
@@ -172,15 +171,9 @@ impl Controller {
 }
 
 #[embassy_executor::task]
-pub async fn usb_task(class: CdcAcmClass<'static, super::UsbDriver>, i2c: super::I2cDriver, bridge_uart: crate::BridgeControlUart, adc: adc::Pins<'static>, gpio: gpio::Pins<'static>) -> ! {
+pub async fn usb_task(class: CdcAcmClass<'static, super::UsbDriver>, i2c: super::I2cDriver, adc: adc::Pins<'static>, gpio: gpio::Pins<'static>) -> ! {
     let (tx, mut rx, mut _ctrl) = class.split_with_control();
-    let mut controller = Controller {
-        tx,
-        i2c,
-        adc,
-        gpio,
-        bridge: bridge::BridgeControl::new(bridge_uart),
-    };
+    let mut controller = Controller { tx, i2c, adc, gpio };
 
     loop {
         rx.wait_connection().await;

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -27,7 +27,7 @@ const FAN_COMMAND: u8 = 9;
 
 #[derive(defmt::Format)]
 struct Command {
-    id: i8,
+    id: u8,
     bus: u8,
     inner: CommandInner,
 }
@@ -43,7 +43,7 @@ enum CommandInner {
 
 impl Command {
     fn from_bytes(buf: &[u8]) -> Result<Self, CommandError> {
-        let id = buf[0] as i8;
+        let id = buf[0];
         match buf[2] {
             I2C_COMMAND => Ok(Self {
                 id,
@@ -72,13 +72,27 @@ impl Command {
 
 #[derive(defmt::Format)]
 pub enum CommandError {
-    Timeout,               // 0x10
-    Invalid,               // 0x11
-    BufferOverflow,        // 0x12
+    Timeout, // 0x10
+    Invalid, // 0x11
+    Denied,  // 0x12
+    Fault,   // 0x13
+    BufferOverflow,
     Message(&'static str), // 0xff
 }
 
 impl CommandError {
+    fn from_protocol(error: crate::bridge_protocol::ProtocolError) -> Self {
+        use crate::bridge_protocol::ProtocolError;
+
+        match error {
+            ProtocolError::Timeout => Self::Timeout,
+            ProtocolError::InvalidCommand | ProtocolError::InvalidFrame | ProtocolError::InvalidResponse => Self::Invalid,
+            ProtocolError::Denied => Self::Denied,
+            ProtocolError::Fault => Self::Fault,
+            ProtocolError::BufferTooSmall => Self::BufferOverflow,
+        }
+    }
+
     fn to_bytes(&self) -> Vec<u8, 260> {
         let mut buf = Vec::<u8, 260>::new();
         buf.extend_from_slice(&[0x00, 0x00, 0xff]).unwrap();
@@ -90,8 +104,14 @@ impl CommandError {
             CommandError::Invalid => {
                 buf.push(0x11).unwrap();
             }
-            CommandError::BufferOverflow => {
+            CommandError::Denied => {
                 buf.push(0x12).unwrap();
+            }
+            CommandError::Fault => {
+                buf.push(0x13).unwrap();
+            }
+            CommandError::BufferOverflow => {
+                buf.extend_from_slice(&[0xff, b'B', b'u', b'f']).unwrap();
             }
             CommandError::Message(msg) => {
                 buf.push(0xff).unwrap();
@@ -134,14 +154,14 @@ impl Controller {
             let buf = match res {
                 Ok(res) => {
                     let mut buf = Vec::<u8, 260>::new();
-                    buf.extend_from_slice(&(res.len() as u16).to_le_bytes()).unwrap();
-                    buf.push(cmd.id as u8).unwrap();
+                    buf.extend_from_slice(&((res.len() + 3) as u16).to_le_bytes()).unwrap();
+                    buf.push(cmd.id).unwrap();
                     buf.extend_from_slice(&res).unwrap();
                     buf
                 }
                 Err(err) => {
                     let mut buf = err.to_bytes();
-                    buf[2] = cmd.id as u8;
+                    buf[2] = cmd.id;
                     buf
                 }
             };
@@ -204,7 +224,15 @@ async fn pipe_usb_read(rx: &mut Receiver<'static, super::UsbDriver>) -> Result<(
 
                             match Command::from_bytes(&buf[2..to_read]) {
                                 Ok(cmd) => COMMAND_CHANNEL.send(cmd).await,
-                                Err(err) => COMMAND_CHANNEL.send(Command { id: -1, bus: 0, inner: CommandInner::Error(err) }).await,
+                                Err(err) => {
+                                    COMMAND_CHANNEL
+                                        .send(Command {
+                                            id: 0xff,
+                                            bus: 0,
+                                            inner: CommandInner::Error(err),
+                                        })
+                                        .await
+                                }
                             }
 
                             let mut new_buf = [0; 4098];

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1,8 +1,7 @@
 use defmt::info;
 
-use embassy_futures::join::join;
+use embassy_futures::select::{select, Either};
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Channel};
-use embassy_time::{Duration, TimeoutError};
 use embassy_usb::{
     class::cdc_acm::{CdcAcmClass, Receiver, Sender},
     driver::EndpointError,
@@ -11,6 +10,9 @@ use heapless::Vec;
 
 pub mod i2c;
 const I2C_COMMAND: u8 = 5;
+
+pub mod system;
+const SYSTEM_COMMAND: u8 = 0;
 
 pub mod bridge;
 pub mod gpio;
@@ -34,6 +36,7 @@ struct Command {
 
 #[derive(defmt::Format)]
 enum CommandInner {
+    System(system::Command),
     I2c(i2c::Command),
     Gpio(gpio::Command),
     Adc(adc::Command),
@@ -43,27 +46,35 @@ enum CommandInner {
 
 impl Command {
     fn from_bytes(buf: &[u8]) -> Result<Self, CommandError> {
-        let id = buf[0];
-        match buf[2] {
+        let [id, bus, page, data @ ..] = buf else {
+            return Err(CommandError::Invalid);
+        };
+
+        match *page {
+            SYSTEM_COMMAND => Ok(Self {
+                id: *id,
+                bus: *bus,
+                inner: CommandInner::System(system::Command::from_bytes(data)?),
+            }),
             I2C_COMMAND => Ok(Self {
-                id,
-                bus: buf[1],
-                inner: CommandInner::I2c(i2c::Command::from_bytes(&buf[3..])?),
+                id: *id,
+                bus: *bus,
+                inner: CommandInner::I2c(i2c::Command::from_bytes(data)?),
             }),
             GPIO_COMMAND => Ok(Self {
-                id,
-                bus: buf[1],
-                inner: CommandInner::Gpio(gpio::Command::from_bytes(&buf[3..])?),
+                id: *id,
+                bus: *bus,
+                inner: CommandInner::Gpio(gpio::Command::from_bytes(data)?),
             }),
             ADC_COMMAND => Ok(Self {
-                id,
-                bus: buf[1],
-                inner: CommandInner::Adc(adc::Command::from_bytes(&buf[3..])?),
+                id: *id,
+                bus: *bus,
+                inner: CommandInner::Adc(adc::Command::from_bytes(data)?),
             }),
             FAN_COMMAND => Ok(Self {
-                id,
-                bus: buf[1],
-                inner: CommandInner::Fan(fan::Command::from_bytes(&buf[3..])?),
+                id: *id,
+                bus: *bus,
+                inner: CommandInner::Fan(fan::Command::from_bytes(data)?),
             }),
             _ => Err(CommandError::Invalid),
         }
@@ -143,6 +154,7 @@ impl Controller {
         loop {
             let cmd = COMMAND_CHANNEL.receive().await;
             let res = match cmd.inner {
+                CommandInner::System(cmd) => cmd.handle(self).await,
                 CommandInner::I2c(cmd) => cmd.handle(self).await,
                 CommandInner::Gpio(cmd) => cmd.handle(self).await,
                 CommandInner::Adc(cmd) => cmd.handle(self).await,
@@ -165,20 +177,29 @@ impl Controller {
                 }
             };
 
-            let _ = self.tx.write_packet(&buf).await;
+            for packet in buf.chunks(64) {
+                if self.tx.write_packet(packet).await.is_err() {
+                    break;
+                }
+            }
         }
     }
 }
 
 #[embassy_executor::task]
 pub async fn usb_task(class: CdcAcmClass<'static, super::UsbDriver>, i2c: super::I2cDriver, adc: adc::Pins<'static>, gpio: gpio::Pins<'static>) -> ! {
-    let (tx, mut rx, mut _ctrl) = class.split_with_control();
+    let (tx, mut rx, mut ctrl) = class.split_with_control();
     let mut controller = Controller { tx, i2c, adc, gpio };
 
     loop {
         rx.wait_connection().await;
+        while !rx.dtr() {
+            ctrl.control_changed().await;
+        }
         info!("Control: Connected");
-        let _ = join(pipe_usb_read(&mut rx), controller.run()).await;
+        let _ = select(pipe_usb_read(&mut rx, &mut ctrl), controller.run()).await;
+        bridge::shutdown().await;
+        while COMMAND_CHANNEL.try_receive().is_ok() {}
         info!("Control: Disconnected");
     }
 }
@@ -196,56 +217,66 @@ impl From<EndpointError> for ControlTaskError {
     }
 }
 
-async fn pipe_usb_read(rx: &mut Receiver<'static, super::UsbDriver>) -> Result<(), ControlTaskError> {
+async fn pipe_usb_read(rx: &mut Receiver<'static, super::UsbDriver>, ctrl: &mut embassy_usb::class::cdc_acm::ControlChanged<'static>) -> Result<(), ControlTaskError> {
     let mut buf = [0; 4098];
+    let mut num_read = 0usize;
 
     loop {
-        let mut num_read: usize = 0;
+        if num_read == buf.len() {
+            COMMAND_CHANNEL
+                .send(Command {
+                    id: buf.get(2).copied().unwrap_or(0xff),
+                    bus: 0,
+                    inner: CommandInner::Error(CommandError::BufferOverflow),
+                })
+                .await;
+            num_read = 0;
+        }
 
-        'read: loop {
-            let read = rx.read_packet(&mut buf[num_read..]);
-
-            match embassy_time::with_timeout(Duration::from_millis(4), read).await {
-                Ok(Ok(n)) => {
-                    num_read += n;
-
-                    if num_read >= 5 {
-                        let to_read = u16::from_le_bytes(buf[0..2].try_into().unwrap()) as usize;
-
-                        if num_read >= to_read {
-                            let excess = num_read - to_read;
-
-                            match Command::from_bytes(&buf[2..to_read]) {
-                                Ok(cmd) => COMMAND_CHANNEL.send(cmd).await,
-                                Err(err) => {
-                                    COMMAND_CHANNEL
-                                        .send(Command {
-                                            id: 0xff,
-                                            bus: 0,
-                                            inner: CommandInner::Error(err),
-                                        })
-                                        .await
-                                }
-                            }
-
-                            let mut new_buf = [0; 4098];
-                            new_buf[..excess].clone_from_slice(&buf[to_read..to_read + excess]);
-
-                            num_read = excess;
-                            buf = new_buf;
-                        }
-                    }
+        let read_result = match select(rx.read_packet(&mut buf[num_read..]), ctrl.control_changed()).await {
+            Either::First(result) => result,
+            Either::Second(()) => {
+                if !rx.dtr() {
+                    return Err(ControlTaskError::Disconnected);
                 }
-
-                Ok(Err(err)) => {
-                    return Err(err.into());
-                }
-
-                Err(TimeoutError) => {
-                    let _error = CommandError::Timeout;
-                    break 'read;
-                }
+                continue;
             }
+        };
+        num_read += read_result?;
+
+        loop {
+            if num_read < 2 {
+                break;
+            }
+
+            let frame_len = u16::from_le_bytes([buf[0], buf[1]]) as usize;
+            if !(6..=buf.len()).contains(&frame_len) {
+                COMMAND_CHANNEL
+                    .send(Command {
+                        id: buf.get(2).copied().unwrap_or(0xff),
+                        bus: 0,
+                        inner: CommandInner::Error(CommandError::Invalid),
+                    })
+                    .await;
+                num_read = 0;
+                break;
+            }
+            if num_read < frame_len {
+                break;
+            }
+
+            let id = buf[2];
+            let command = match Command::from_bytes(&buf[2..frame_len]) {
+                Ok(command) => command,
+                Err(error) => Command { id, bus: 0, inner: CommandInner::Error(error) },
+            };
+            COMMAND_CHANNEL.send(command).await;
+
+            let remaining = num_read - frame_len;
+            if remaining != 0 {
+                buf.copy_within(frame_len..num_read, 0);
+            }
+            num_read = remaining;
         }
     }
 }

--- a/src/control/system.rs
+++ b/src/control/system.rs
@@ -1,0 +1,33 @@
+use heapless::Vec;
+
+use super::CommandError;
+use crate::bridge_protocol;
+
+#[derive(defmt::Format)]
+pub enum Command {
+    GetInfo,
+    GetRxStats,
+    GetSafetyStatus,
+}
+
+impl Command {
+    pub fn from_bytes(buf: &[u8]) -> Result<Self, CommandError> {
+        match buf {
+            [bridge_protocol::SYSTEM_GET_INFO] => Ok(Self::GetInfo),
+            [bridge_protocol::SYSTEM_GET_RX_STATS] => Ok(Self::GetRxStats),
+            [bridge_protocol::SYSTEM_GET_SAFETY_STATUS] => Ok(Self::GetSafetyStatus),
+            _ => Err(CommandError::Invalid),
+        }
+    }
+}
+
+impl super::ControllerCommand for Command {
+    async fn handle(&self, _controller: &mut super::Controller) -> Result<Vec<u8, 256>, CommandError> {
+        let command = match self {
+            Self::GetInfo => bridge_protocol::SYSTEM_GET_INFO,
+            Self::GetRxStats => bridge_protocol::SYSTEM_GET_RX_STATS,
+            Self::GetSafetyStatus => bridge_protocol::SYSTEM_GET_SAFETY_STATUS,
+        };
+        super::bridge::system(command).await
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ pub type UsbDevice = embassy_usb::UsbDevice<'static, UsbDriver>;
 const VERSION: u16 = 0x0001;
 
 static MANUFACTURER: &str = "OSMU";
-static PRODUCT: &str = "Bitaxe";
+static PRODUCT: &str = "BitaxeBonanza";
 
 /// Return a unique serial number for this device by hashing its MAC address
 fn serial_number() -> &'static str {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use esp_hal::{
 };
 use static_cell::StaticCell;
 
+mod bridge_protocol;
 mod control;
 mod uart;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,8 @@ async fn main(spawner: Spawner) {
     };
 
     unwrap!(spawner.spawn(usb_task(builder.build())));
-    unwrap!(spawner.spawn(control::usb_task(control_class, i2c, bridge_control_uart, adc_pins, gpio_pins)));
+    unwrap!(spawner.spawn(control::bridge::manager_task(bridge_control_uart)));
+    unwrap!(spawner.spawn(control::usb_task(control_class, i2c, adc_pins, gpio_pins)));
     unwrap!(spawner.spawn(uart::usb_task(asic_uart_class, asic_uart)));
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,7 @@ async fn main(spawner: Spawner) {
     };
 
     let asic_uart = {
-        let config = esp_hal::uart::Config::default().with_baudrate(115200).with_rx(esp_hal::uart::RxConfig::default().with_fifo_full_threshold(64));
+        let config = esp_hal::uart::Config::default().with_baudrate(5_000_000).with_rx(esp_hal::uart::RxConfig::default().with_fifo_full_threshold(64));
         esp_hal::uart::Uart::new(p.UART1, config).unwrap().with_rx(p.GPIO18).with_tx(p.GPIO17).into_async()
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ const VERSION: u16 = 0x0001;
 
 static MANUFACTURER: &str = "OSMU";
 static PRODUCT: &str = "BitaxeBonanza";
+const BRIDGE_DATA_BAUDRATE: u32 = 2_000_000;
 
 /// Return a unique serial number for this device by hashing its MAC address
 fn serial_number() -> &'static str {
@@ -97,7 +98,7 @@ async fn main(spawner: Spawner) {
     };
 
     let asic_uart = {
-        let config = esp_hal::uart::Config::default().with_baudrate(5_000_000).with_rx(esp_hal::uart::RxConfig::default().with_fifo_full_threshold(64));
+        let config = esp_hal::uart::Config::default().with_baudrate(BRIDGE_DATA_BAUDRATE).with_rx(esp_hal::uart::RxConfig::default().with_fifo_full_threshold(64));
         esp_hal::uart::Uart::new(p.UART1, config).unwrap().with_rx(p.GPIO18).with_tx(p.GPIO17).into_async()
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,13 @@ esp_bootloader_esp_idf::esp_app_desc!();
 
 use embassy_executor::Spawner;
 use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
-use esp_hal::{analog::adc, clock::CpuClock, i2c, timer::systimer::SystemTimer};
+use esp_hal::{
+    analog::adc,
+    clock::CpuClock,
+    gpio::{Input, InputConfig, Level, Output, OutputConfig},
+    i2c,
+    timer::systimer::SystemTimer,
+};
 use static_cell::StaticCell;
 
 mod control;
@@ -111,8 +117,13 @@ async fn main(spawner: Spawner) {
     let adc = adc::Adc::new(p.ADC1, Default::default());
     let adc_pins = control::adc::Pins { adc, vdd: vdd };
 
+    let gpio_pins = control::gpio::Pins {
+        vr_en: Output::new(p.GPIO10, Level::Low, OutputConfig::default()),
+        vr_pgood: Input::new(p.GPIO11, InputConfig::default()),
+    };
+
     unwrap!(spawner.spawn(usb_task(builder.build())));
-    unwrap!(spawner.spawn(control::usb_task(control_class, i2c, bridge_control_uart, adc_pins)));
+    unwrap!(spawner.spawn(control::usb_task(control_class, i2c, bridge_control_uart, adc_pins, gpio_pins)));
     unwrap!(spawner.spawn(uart::usb_task(asic_uart_class, asic_uart)));
 }
 

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -71,6 +71,14 @@ pub async fn pipe_uart<'d>(
     let mut usb_buf = [0; 64];
     let mut uart_buf = [0; 1024];
 
+    let line_coding = usb_rx.line_coding();
+    let baudrate = line_coding.data_rate();
+    if baudrate != 0 {
+        let config = Config::default().with_baudrate(baudrate);
+        uart_tx.set_config(&config)?;
+        uart_rx.set_config(&config)?;
+    }
+
     loop {
         let usb_read = usb_rx.read_packet(&mut usb_buf);
         let uart_read = uart_rx.read_async(&mut uart_buf);

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -3,15 +3,14 @@ pub enum UartTaskError {
     UartError,
 }
 
-use embassy_embedded_hal::SetConfig;
-use embassy_futures::select::{select3, Either3};
+use embassy_futures::select::{select, Either};
 use embassy_usb::{
-    class::cdc_acm::{CdcAcmClass, ControlChanged, Receiver, Sender},
+    class::cdc_acm::{CdcAcmClass, Receiver, Sender},
     driver::EndpointError,
 };
 use embedded_io_async::Write;
 use esp_hal::{
-    uart::{Config, ConfigError, RxError, TxError, Uart, UartRx, UartTx},
+    uart::{RxError, TxError, Uart, UartRx, UartTx},
     Async,
 };
 
@@ -40,69 +39,42 @@ impl From<RxError> for UartTaskError {
     }
 }
 
-impl From<ConfigError> for UartTaskError {
-    fn from(val: ConfigError) -> Self {
-        match val {
-            _ => UartTaskError::UartError,
-        }
-    }
-}
-
 #[embassy_executor::task]
 pub async fn usb_task(class: CdcAcmClass<'static, super::UsbDriver>, uart: Uart<'static, Async>) -> ! {
-    let (mut tx, mut rx, mut ctrl) = class.split_with_control();
+    let (mut tx, mut rx, mut _ctrl) = class.split_with_control();
 
     let (mut uart_rx, mut uart_tx) = uart.split();
 
     loop {
         rx.wait_connection().await;
-        let _ = pipe_uart(&mut tx, &mut rx, &mut ctrl, &mut uart_rx, &mut uart_tx).await;
+        let _ = pipe_uart(&mut tx, &mut rx, &mut uart_rx, &mut uart_tx).await;
     }
 }
 
-/// Handle ASIC UART <-> BMC USB TTY forwarding and baudrate changes
-pub async fn pipe_uart<'d>(
-    usb_tx: &mut Sender<'static, super::UsbDriver>,
-    usb_rx: &mut Receiver<'static, super::UsbDriver>,
-    ctrl: &mut ControlChanged<'static>,
-    uart_rx: &mut UartRx<'d, Async>,
-    uart_tx: &mut UartTx<'d, Async>,
-) -> Result<(), UartTaskError> {
+/// Handle ASIC UART <-> BMC USB TTY forwarding.
+///
+/// USB CDC line coding is intentionally ignored. The physical ESP-to-Bridge
+/// UART must remain at the Bridge protocol's fixed baud rate.
+pub async fn pipe_uart<'d>(usb_tx: &mut Sender<'static, super::UsbDriver>, usb_rx: &mut Receiver<'static, super::UsbDriver>, uart_rx: &mut UartRx<'d, Async>, uart_tx: &mut UartTx<'d, Async>) -> Result<(), UartTaskError> {
     let mut usb_buf = [0; 64];
     let mut uart_buf = [0; 1024];
-
-    let line_coding = usb_rx.line_coding();
-    let baudrate = line_coding.data_rate();
-    if baudrate != 0 {
-        let config = Config::default().with_baudrate(baudrate);
-        uart_tx.set_config(&config)?;
-        uart_rx.set_config(&config)?;
-    }
 
     loop {
         let usb_read = usb_rx.read_packet(&mut usb_buf);
         let uart_read = uart_rx.read_async(&mut uart_buf);
 
-        let control_change = ctrl.control_changed();
-
-        match select3(usb_read, uart_read, control_change).await {
+        match select(usb_read, uart_read).await {
             // Forward data from the USB host to the UART
-            Either3::First(n) => {
+            Either::First(n) => {
                 let data = &usb_buf[..n?];
                 uart_tx.write_all(data).await?;
             }
             // Forward data from the UART back to the USB host
-            Either3::Second(n) => {
+            Either::Second(n) => {
                 let data = &uart_buf[..n?];
-                usb_tx.write_packet(data).await?;
-            }
-            // Handle baudrate changes from USB CDC control requests
-            Either3::Third(()) => {
-                let line_coding = usb_rx.line_coding();
-                let baudrate = line_coding.data_rate();
-                let config = Config::default().with_baudrate(baudrate);
-                uart_tx.set_config(&config)?;
-                uart_rx.set_config(&config)?;
+                for packet in data.chunks(64) {
+                    usb_tx.write_packet(packet).await?;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Identify the USB product as `BitaxeBonanza` and expose the Bonanza VR enable and power-good GPIO controls from #13.
- Support Bonanza Bridge protocol 1 with hardened request/response framing and read-only firmware, RX-statistics, and safety diagnostics.
- Let the raw firmware own the Bridge safety lease. Existing clients can continue using the legacy GPIO interface while the firmware handles compatibility checks, arming, heartbeats, recoverable fault clearing, and fail-safe shutdown.
- Keep the physical ESP-to-Bridge data UART at the required 2 Mbaud while accepting clients that configure the USB CDC port for a legacy baud rate.
- Treat repeated unsafe GPIO writes as idempotent when the requested level is already active.

## Why

The latest Bonanza Bridge firmware requires an explicit safety lease before enabling 5 V, releasing ASIC reset, or reducing the fan from 100%. The raw firmware is the trusted Bridge client, so it owns and renews that lease internally without adding lease-management requirements to BIRDS or other developer clients.

Closing the control port or encountering a Bridge error asserts ASIC reset, disables 5 V, forces the fan to 100%, and disarms the lease.

This supersedes #13.

## Validation

- All 8 Bridge protocol unit tests pass.
- The locked ESP32-S3 release build succeeds.
- Flashed and tested on an attached BitaxeBonanza with Bridge protocol 1.0 and firmware `0.0.1+g4fea080`.
- The unchanged local BIRDS `bzmd` client detected all four ASICs, reported all engines working, and completed system power-on in 4 seconds.
- A client-selected 5 Mbaud USB CDC setting successfully communicated with the ASIC over the fixed 2 Mbaud physical Bridge link.
- Repeated legacy 5 V enable passed while the safety lease remained healthy.
- Bridge FIFO and ring overflow counters remained zero.
- Client disconnect returned the board to safe-off with 5 V disabled, ASIC reset asserted, fan at 100%, no active lease, and no fault.
